### PR TITLE
fix(layers): repair compact layer list layout

### DIFF
--- a/editor/styles/layers-region.css
+++ b/editor/styles/layers-region.css
@@ -1,38 +1,18 @@
 /* =============================================================================
  * layers-region.css — persistent Layers panel styles (ADR-031 + ADR-032)
  *
- * Status in v1.1.0: SCAFFOLD (empty).
- *
- * This CSS layer is reserved for the persistent layers panel that is activated
- * in Phase B (v1.2.0) when feature flag `ui.layersStandalone` flips to true and
- * `ui.layoutVersion` flips to "v2".
- *
- * In v1.1.0 the layers panel still lives inside the inspector section. No styles
- * are applied by this file. See tokens.css for the @layer declaration that
- * reserves the ordering slot (between broken-asset-banner and inspector).
- *
- * Related ADRs:
- *   - ADR-031 Persistent Layers Panel
- *   - ADR-032 Workspace Layout v2 (Figma-style split-pane)
- *   - ADR-034 Layer Tree DnD
- * =============================================================================
- */
+ * Shell-side styles for the standalone Layers panel and inspector-hosted
+ * layers list. This file must keep the layers area compact: the left rail is
+ * narrow, so rows should behave like a dense object list, not large cards.
+ * ============================================================================= */
 
 @layer layers-region {
-  /*
-   * v1.1.3 — activated scaffold.
-   * The panel uses flex layout when visible so the list container consumes
-   * remaining height and scrolls independently of the header.
-   */
   #layersRegion {
     display: flex;
     flex-direction: column;
     min-height: 0;
     overflow: hidden;
   }
-
-  /* When [hidden] is set by JS (layers-panel.js), `display:none` wins via the
-     UA stylesheet. No override needed. */
 
   #layersRegion .panel-header {
     flex: 0 0 auto;
@@ -42,59 +22,38 @@
     flex: 1 1 auto;
     min-height: 0;
     overflow: auto;
-    /* The list container is appended here by ensureLayersContainerPlacement(). */
-    padding: 12px 16px 16px;
+    padding: 8px;
   }
 
-  /* When the list lives inside the region, drop the inspector-section
-     paddings so the layout looks shell-native. The container itself still
-     owns its internal gap. */
   #layersRegion .layers-list-container {
     width: 100%;
   }
 
-  /* -------------------------------------------------------------------------
-   * v1.1.5 / ADR-034 — Tree view (featureFlags.treeLayers)
-   * ----------------------------------------------------------------------- */
-
-  /* Depth-based left padding on rows. --layer-depth is 0 for roots, grows +1
-     per nesting level. 10px per level keeps labels readable in narrow
-     columns; capped at min(depth * 10px, 80px) so very deep trees still
-     leave room for the label. [v2.0.3] reduced from 14px → 10px + cap. */
+  /* Tree view -------------------------------------------------------------- */
   .layer-row[data-layer-depth] {
-    padding-left: min(calc(var(--layer-depth, 0) * 10px), 80px);
+    padding-left: min(calc(var(--layer-depth, 0) * 6px), 36px);
   }
 
-  /* Collapsible sub-tree wrapper. Summary acts as the clickable row; children
-     live in .layer-tree-children. */
   .layers-list-container.is-tree-mode .layer-tree-node {
     display: block;
+    position: relative;
   }
 
   .layers-list-container.is-tree-mode .layer-tree-node > summary {
     list-style: none;
     cursor: pointer;
     position: relative;
-    /* [v2.0.5] Summary has .layer-row grid (32px | 1fr | auto). We MUST
-       keep the ::before disclosure arrow OUT of the grid flow — otherwise
-       it occupies the first cell, shifts every other child right by one
-       column, and trailing actions (eye/lock) overflow into an implicit
-       2nd row on the LEFT edge. Pseudo stays position:absolute so grid
-       cell assignment is unaffected. Extra left padding reserves space
-       for the arrow so labels don't collide with it. */
-    padding-left: 14px;
+    padding-left: 18px;
   }
 
   .layers-list-container.is-tree-mode .layer-tree-node > summary::-webkit-details-marker {
     display: none;
   }
 
-  /* Custom disclosure arrow — rotates 90° when <details open>. Positioned
-     absolute so it does not participate in the grid row/column layout. */
   .layers-list-container.is-tree-mode .layer-tree-node > summary::before {
     content: "";
     position: absolute;
-    left: 0;
+    left: 6px;
     top: 50%;
     width: 0;
     height: 0;
@@ -102,61 +61,51 @@
     border-left-color: currentColor;
     transform: translateY(-50%);
     transform-origin: 2px 50%;
-    transition: transform var(--motion-micro, 120ms) var(--ease-out, ease);
-    opacity: 0.6;
+    opacity: 0.58;
     pointer-events: none;
+    transition: transform var(--motion-micro, 120ms) var(--ease-out, ease);
   }
 
   .layers-list-container.is-tree-mode .layer-tree-node[open] > summary::before {
     transform: translateY(-50%) rotate(90deg);
   }
 
-  /* [v2.0.16 / A11Y-001] When the row is rendered as <summary> (parent in
-     tree), the visibility/lock action buttons are hoisted to a SIBLING
-     .layer-row-actions.is-detached node so they're not descendants of an
-     implicitly-interactive element (eliminates nested-interactive WCAG
-     violation). Position them absolutely over the summary's right edge so
-     the visual stays inline. */
-  .layers-list-container.is-tree-mode .layer-tree-node {
-    position: relative;
-  }
-
   .layers-list-container.is-tree-mode .layer-tree-node > .layer-row-actions.is-detached {
     position: absolute;
-    top: 4px;
+    top: 50%;
     right: 6px;
-    display: flex;
-    gap: 2px;
     z-index: 2;
+    display: flex;
+    gap: 3px;
+    transform: translateY(-50%);
     pointer-events: auto;
   }
 
-  /* Reserve space at the right of summary content so labels don't collide
-     with the detached actions. */
   .layers-list-container.is-tree-mode .layer-tree-node > summary .layer-trailing {
-    padding-right: 56px;
+    padding-right: 58px;
   }
 
   .layers-list-container.is-tree-mode .layer-tree-children {
     display: block;
+    margin: 4px 0 0 8px;
+    padding-left: 6px;
+    border-left: 1px solid color-mix(in srgb, var(--shell-border-strong) 44%, transparent);
   }
 
   .layers-list-container.is-tree-mode .layer-tree-node:not([open]) .layer-tree-children {
     display: none;
   }
 
-  /* -------------------------------------------------------------------------
-   * v1.1.6 / Phase B5 — Inline rename input
-   * Replaces .layer-label span while editing; visually matches the label.
-   * ----------------------------------------------------------------------- */
+  /* Inline rename ---------------------------------------------------------- */
   .layer-label-input {
     width: 100%;
-    font: inherit;
-    color: inherit;
-    background: var(--surface-elevated, rgba(255, 255, 255, 0.9));
+    min-height: 26px;
+    padding: 3px 7px;
     border: 1px solid var(--border-accent, rgba(0, 113, 227, 0.35));
-    border-radius: 4px;
-    padding: 2px 6px;
+    border-radius: 7px;
+    background: var(--surface-elevated, rgba(255, 255, 255, 0.9));
+    color: inherit;
+    font: inherit;
     outline: none;
     box-shadow: 0 0 0 2px var(--state-focus-ring, rgba(0, 113, 227, 0.18));
   }
@@ -167,249 +116,122 @@
 }
 
 /* =============================================================================
- * v2.1 UX pass — novice-friendly layers list
+ * Compact repair layer — fixes the oversized PR #7 layout.
  *
- * This block intentionally lives outside @layer so it acts as the final layer
- * usability correction over inspector/onboarding polish. It targets shell layer
- * rows only and does not touch iframe presentation content.
+ * Goal: the Layers section must fit a narrow rail. Rows are compact, readable,
+ * and click-safe: row selects, eye/lock act as separate controls, labels do
+ * not sit under action buttons, tree indentation is shallow.
  * ============================================================================= */
 
+#layersRegion .panel-header {
+  min-height: 44px !important;
+  padding: 9px 12px !important;
+}
+
+#layersRegion .panel-header h2 {
+  font-size: 11px !important;
+  letter-spacing: 0.08em !important;
+}
+
+#layersRegion .panel-subtext {
+  max-width: 26ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px !important;
+}
+
 #layersRegion .layers-region-body {
-  padding: 12px !important;
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--premium-panel, var(--shell-panel)) 92%, transparent),
-      color-mix(in srgb, var(--premium-panel-soft, var(--shell-panel)) 76%, transparent)
-    );
+  padding: 8px !important;
+  background: color-mix(in srgb, var(--premium-panel, var(--shell-panel)) 94%, transparent) !important;
 }
 
 #layersRegion .layers-list-container,
 #layersInspectorSection .layers-list-container {
   display: flex !important;
   flex-direction: column !important;
-  gap: 8px !important;
-  padding: 10px !important;
-  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 86%, transparent) !important;
-  border-radius: 16px !important;
-  background: color-mix(in srgb, var(--premium-panel-soft, var(--shell-field-bg)) 82%, transparent) !important;
+  gap: 5px !important;
+  max-height: none !important;
+  padding: 6px !important;
+  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 70%, transparent) !important;
+  border-radius: 12px !important;
+  background: color-mix(in srgb, var(--premium-panel-soft, var(--shell-field-bg)) 72%, transparent) !important;
+  overflow: auto !important;
 }
 
+/* Hide the bulky helper from PR #7. The header already says this is Layers. */
 #layersRegion .layers-list-container::before,
 #layersInspectorSection .layers-list-container::before {
-  content: "Клик по строке — выбрать слой. 👁 скрыть. 🔒 защитить.";
-  display: block;
-  padding: 8px 10px 9px;
-  border: 1px solid color-mix(in srgb, var(--shell-accent) 16%, var(--premium-border, var(--shell-border-strong))) !important;
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--shell-accent-soft) 34%, var(--premium-panel, var(--shell-panel)) 66%);
-  color: var(--shell-text-muted);
-  font-size: 11px;
-  line-height: 1.35;
+  display: none !important;
+  content: none !important;
 }
 
 #layersRegion .layer-row,
 #layersInspectorSection .layer-row {
   position: relative !important;
   display: grid !important;
-  grid-template-columns: 30px 34px minmax(0, 1fr) minmax(72px, auto) !important;
+  grid-template-columns: 26px minmax(0, 1fr) auto !important;
   align-items: center !important;
-  gap: 8px !important;
-  min-height: 58px !important;
-  padding: 9px 10px !important;
-  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 78%, transparent) !important;
-  border-radius: 14px !important;
-  background: color-mix(in srgb, var(--premium-panel, var(--shell-panel)) 92%, transparent) !important;
-  box-shadow: 0 1px 2px color-mix(in srgb, #0f172a 5%, transparent) !important;
+  gap: 6px !important;
+  min-height: 44px !important;
+  padding: 6px 7px !important;
+  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 58%, transparent) !important;
+  border-radius: 11px !important;
+  background: color-mix(in srgb, var(--premium-panel, var(--shell-panel)) 94%, transparent) !important;
+  box-shadow: none !important;
   cursor: pointer !important;
   touch-action: manipulation;
 }
 
-#layersRegion .layer-row::after,
-#layersInspectorSection .layer-row::after {
-  content: "";
-  position: absolute;
-  inset: -2px;
-  border-radius: 16px;
-  pointer-events: none;
+#layersRegion .layer-row:has(.layer-drag-handle),
+#layersInspectorSection .layer-row:has(.layer-drag-handle) {
+  grid-template-columns: 22px 26px minmax(0, 1fr) auto !important;
 }
 
 #layersRegion .layer-row:hover,
 #layersInspectorSection .layer-row:hover {
-  border-color: color-mix(in srgb, var(--shell-accent) 46%, var(--premium-border, var(--shell-border-strong))) !important;
-  background: color-mix(in srgb, var(--premium-panel, var(--shell-panel)) 78%, var(--shell-accent-soft) 22%) !important;
-  box-shadow: 0 8px 20px color-mix(in srgb, var(--shell-accent) 10%, transparent) !important;
+  border-color: color-mix(in srgb, var(--shell-accent) 34%, var(--premium-border, var(--shell-border-strong))) !important;
+  background: color-mix(in srgb, var(--premium-panel, var(--shell-panel)) 82%, var(--shell-accent-soft) 18%) !important;
+  box-shadow: 0 3px 10px color-mix(in srgb, var(--shell-accent) 8%, transparent) !important;
 }
 
 #layersRegion .layer-row.is-active,
 #layersInspectorSection .layer-row.is-active,
 #layersRegion .layer-row[aria-current="true"],
 #layersInspectorSection .layer-row[aria-current="true"] {
-  border-color: color-mix(in srgb, var(--shell-accent) 78%, var(--premium-border, var(--shell-border-strong))) !important;
-  background:
-    linear-gradient(
-      90deg,
-      color-mix(in srgb, var(--shell-accent-soft) 62%, var(--premium-panel, var(--shell-panel)) 38%),
-      color-mix(in srgb, var(--premium-panel, var(--shell-panel)) 80%, var(--shell-accent-soft) 20%)
-    ) !important;
+  border-color: color-mix(in srgb, var(--shell-accent) 68%, var(--premium-border, var(--shell-border-strong))) !important;
+  background: color-mix(in srgb, var(--premium-panel, var(--shell-panel)) 76%, var(--shell-accent-soft) 24%) !important;
   box-shadow:
-    inset 4px 0 0 var(--shell-accent),
-    0 0 0 1px color-mix(in srgb, var(--shell-accent) 24%, transparent),
-    0 10px 22px color-mix(in srgb, var(--shell-accent) 14%, transparent) !important;
+    inset 3px 0 0 var(--shell-accent),
+    0 0 0 1px color-mix(in srgb, var(--shell-accent) 16%, transparent) !important;
 }
 
 #layersRegion .layer-row:focus-visible,
 #layersInspectorSection .layer-row:focus-visible {
-  outline: 3px solid color-mix(in srgb, var(--shell-accent) 42%, transparent) !important;
+  outline: 2px solid color-mix(in srgb, var(--shell-accent) 48%, transparent) !important;
   outline-offset: 2px !important;
 }
 
-#layersRegion .layer-type-glyph,
-#layersInspectorSection .layer-type-glyph {
-  width: 32px !important;
-  height: 32px !important;
-  display: inline-grid !important;
-  place-items: center !important;
-  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 72%, transparent) !important;
-  border-radius: 10px !important;
-  background: color-mix(in srgb, var(--premium-control-bg, var(--shell-field-bg)) 82%, transparent) !important;
-  color: var(--shell-text) !important;
-  font-size: 13px !important;
-  font-weight: 760 !important;
-  line-height: 1 !important;
-}
-
-#layersRegion .layer-row.is-active .layer-type-glyph,
-#layersInspectorSection .layer-row.is-active .layer-type-glyph,
-#layersRegion .layer-row[aria-current="true"] .layer-type-glyph,
-#layersInspectorSection .layer-row[aria-current="true"] .layer-type-glyph {
-  border-color: color-mix(in srgb, var(--shell-accent) 50%, var(--premium-border, var(--shell-border-strong))) !important;
-  background: color-mix(in srgb, var(--shell-accent-soft) 64%, var(--premium-control-bg, var(--shell-field-bg)) 36%) !important;
-  color: var(--shell-accent) !important;
-}
-
-#layersRegion .layer-main,
-#layersInspectorSection .layer-main {
-  min-width: 0 !important;
-  gap: 3px !important;
-}
-
-#layersRegion .layer-label,
-#layersInspectorSection .layer-label {
-  display: block !important;
-  max-width: 100% !important;
-  overflow: hidden !important;
-  text-overflow: ellipsis !important;
-  white-space: nowrap !important;
-  color: var(--shell-text) !important;
-  font-size: 13px !important;
-  font-weight: 760 !important;
-  line-height: 1.25 !important;
-}
-
-#layersRegion .layer-meta,
-#layersInspectorSection .layer-meta {
-  display: block !important;
-  max-width: 100% !important;
-  overflow: hidden !important;
-  text-overflow: ellipsis !important;
-  white-space: nowrap !important;
-  color: var(--shell-text-muted) !important;
-  font-size: 10.5px !important;
-  line-height: 1.3 !important;
-}
-
-#layersRegion .layer-trailing,
-#layersInspectorSection .layer-trailing {
-  display: flex !important;
-  justify-content: flex-end !important;
-  align-items: center !important;
-  gap: 6px !important;
-  min-width: 0 !important;
-}
-
-#layersRegion .layer-status-list,
-#layersInspectorSection .layer-status-list {
-  display: flex !important;
-  flex-wrap: wrap !important;
-  justify-content: flex-end !important;
-  gap: 4px !important;
-  max-width: 88px !important;
-}
-
-#layersRegion .layer-status-chip,
-#layersInspectorSection .layer-status-chip {
-  min-height: 20px !important;
-  padding: 2px 7px !important;
-  border-radius: 999px !important;
-  font-size: 10px !important;
-  font-weight: 650 !important;
-  line-height: 1 !important;
-  white-space: nowrap !important;
-}
-
-#layersRegion .layer-row-actions,
-#layersInspectorSection .layer-row-actions {
-  display: inline-flex !important;
-  align-items: center !important;
-  justify-content: flex-end !important;
-  gap: 4px !important;
-}
-
-#layersRegion .layer-action-btn,
-#layersInspectorSection .layer-action-btn,
 #layersRegion .layer-drag-handle,
 #layersInspectorSection .layer-drag-handle {
-  width: 34px !important;
-  min-width: 34px !important;
-  height: 34px !important;
-  min-height: 34px !important;
-  display: inline-grid !important;
-  place-items: center !important;
-  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 72%, transparent) !important;
-  border-radius: 10px !important;
-  background: color-mix(in srgb, var(--premium-control-bg, var(--shell-field-bg)) 82%, transparent) !important;
-  color: var(--shell-text-muted) !important;
-  cursor: pointer !important;
+  width: 22px !important;
+  min-width: 22px !important;
+  height: 28px !important;
+  min-height: 28px !important;
+  padding: 0 !important;
+  border: 0 !important;
+  border-radius: 7px !important;
+  background: transparent !important;
+  color: color-mix(in srgb, var(--shell-text-muted) 78%, transparent) !important;
+  cursor: grab !important;
 }
 
-#layersRegion .layer-action-btn:hover,
-#layersInspectorSection .layer-action-btn:hover,
 #layersRegion .layer-drag-handle:hover,
 #layersInspectorSection .layer-drag-handle:hover,
-#layersRegion .layer-action-btn:focus-visible,
-#layersInspectorSection .layer-action-btn:focus-visible,
 #layersRegion .layer-drag-handle:focus-visible,
 #layersInspectorSection .layer-drag-handle:focus-visible {
-  border-color: color-mix(in srgb, var(--shell-accent) 42%, var(--premium-border, var(--shell-border-strong))) !important;
-  background: color-mix(in srgb, var(--shell-accent-soft) 56%, var(--premium-control-bg, var(--shell-field-bg)) 44%) !important;
+  background: color-mix(in srgb, var(--shell-accent-soft) 44%, transparent) !important;
   color: var(--shell-accent) !important;
-}
-
-#layersRegion .layer-action-btn:active,
-#layersInspectorSection .layer-action-btn:active,
-#layersRegion .layer-drag-handle:active,
-#layersInspectorSection .layer-drag-handle:active {
-  transform: scale(0.97) !important;
-}
-
-#layersRegion .layer-action-btn.is-hidden,
-#layersInspectorSection .layer-action-btn.is-hidden {
-  opacity: 1 !important;
-  color: var(--shell-text-muted) !important;
-  background: color-mix(in srgb, var(--shell-text-muted) 12%, var(--premium-control-bg, var(--shell-field-bg)) 88%) !important;
-}
-
-#layersRegion .layer-action-btn.is-locked,
-#layersInspectorSection .layer-action-btn.is-locked,
-#layersRegion .layer-status-chip.is-locked,
-#layersInspectorSection .layer-status-chip.is-locked {
-  color: var(--intent-error-fg, var(--shell-danger)) !important;
-}
-
-#layersRegion .layer-drag-handle,
-#layersInspectorSection .layer-drag-handle {
-  cursor: grab !important;
 }
 
 #layersRegion .layer-drag-handle:active,
@@ -417,9 +239,137 @@
   cursor: grabbing !important;
 }
 
+#layersRegion .layer-type-glyph,
+#layersInspectorSection .layer-type-glyph {
+  width: 26px !important;
+  min-width: 26px !important;
+  height: 26px !important;
+  min-height: 26px !important;
+  display: inline-grid !important;
+  place-items: center !important;
+  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 54%, transparent) !important;
+  border-radius: 8px !important;
+  background: color-mix(in srgb, var(--premium-control-bg, var(--shell-field-bg)) 78%, transparent) !important;
+  color: var(--shell-text-muted) !important;
+  font-size: 12px !important;
+  font-weight: 700 !important;
+  line-height: 1 !important;
+}
+
+#layersRegion .layer-row.is-active .layer-type-glyph,
+#layersInspectorSection .layer-row.is-active .layer-type-glyph,
+#layersRegion .layer-row[aria-current="true"] .layer-type-glyph,
+#layersInspectorSection .layer-row[aria-current="true"] .layer-type-glyph {
+  border-color: color-mix(in srgb, var(--shell-accent) 42%, var(--premium-border, var(--shell-border-strong))) !important;
+  background: color-mix(in srgb, var(--shell-accent-soft) 52%, var(--premium-control-bg, var(--shell-field-bg)) 48%) !important;
+  color: var(--shell-accent) !important;
+}
+
+#layersRegion .layer-main,
+#layersInspectorSection .layer-main {
+  min-width: 0 !important;
+  display: grid !important;
+  gap: 2px !important;
+}
+
+#layersRegion .layer-label,
+#layersInspectorSection .layer-label {
+  display: block !important;
+  min-width: 0 !important;
+  max-width: 100% !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+  color: var(--shell-text) !important;
+  font-size: 12px !important;
+  font-weight: 700 !important;
+  line-height: 1.2 !important;
+}
+
+#layersRegion .layer-meta,
+#layersInspectorSection .layer-meta {
+  display: block !important;
+  min-width: 0 !important;
+  max-width: 100% !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+  color: var(--shell-text-muted) !important;
+  font-size: 10px !important;
+  line-height: 1.2 !important;
+}
+
+#layersRegion .layer-trailing,
+#layersInspectorSection .layer-trailing {
+  min-width: 0 !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: flex-end !important;
+  gap: 4px !important;
+}
+
+/* Status chips created horizontal pressure in the rail. State remains visible
+   through the eye/lock icons; detailed chips belong in inspector, not this list. */
+#layersRegion .layer-status-list,
+#layersInspectorSection .layer-status-list {
+  display: none !important;
+}
+
+#layersRegion .layer-row-actions,
+#layersInspectorSection .layer-row-actions {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: flex-end !important;
+  gap: 3px !important;
+  min-width: 0 !important;
+}
+
+#layersRegion .layer-action-btn,
+#layersInspectorSection .layer-action-btn {
+  width: 28px !important;
+  min-width: 28px !important;
+  height: 28px !important;
+  min-height: 28px !important;
+  padding: 0 !important;
+  display: inline-grid !important;
+  place-items: center !important;
+  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 58%, transparent) !important;
+  border-radius: 9px !important;
+  background: color-mix(in srgb, var(--premium-control-bg, var(--shell-field-bg)) 70%, transparent) !important;
+  color: var(--shell-text-muted) !important;
+  cursor: pointer !important;
+}
+
+#layersRegion .layer-action-btn:hover,
+#layersInspectorSection .layer-action-btn:hover,
+#layersRegion .layer-action-btn:focus-visible,
+#layersInspectorSection .layer-action-btn:focus-visible {
+  border-color: color-mix(in srgb, var(--shell-accent) 40%, var(--premium-border, var(--shell-border-strong))) !important;
+  background: color-mix(in srgb, var(--shell-accent-soft) 54%, var(--premium-control-bg, var(--shell-field-bg)) 46%) !important;
+  color: var(--shell-accent) !important;
+}
+
+#layersRegion .layer-action-btn:active,
+#layersInspectorSection .layer-action-btn:active {
+  transform: scale(0.97) !important;
+}
+
+#layersRegion .layer-action-btn.is-hidden,
+#layersInspectorSection .layer-action-btn.is-hidden {
+  opacity: 1 !important;
+  color: color-mix(in srgb, var(--shell-text-muted) 72%, transparent) !important;
+  background: color-mix(in srgb, var(--shell-text-muted) 10%, var(--premium-control-bg, var(--shell-field-bg)) 90%) !important;
+}
+
+#layersRegion .layer-action-btn.is-locked,
+#layersInspectorSection .layer-action-btn.is-locked {
+  color: var(--intent-error-fg, var(--shell-danger)) !important;
+}
+
+/* Compact tree mode: nesting indicator without wasting half the rail. */
 #layersRegion .layers-list-container.is-tree-mode,
 #layersInspectorSection .layers-list-container.is-tree-mode {
-  gap: 6px !important;
+  gap: 4px !important;
 }
 
 #layersRegion .layers-list-container.is-tree-mode .layer-tree-node,
@@ -429,86 +379,69 @@
 
 #layersRegion .layers-list-container.is-tree-mode .layer-tree-node > summary.layer-row,
 #layersInspectorSection .layers-list-container.is-tree-mode .layer-tree-node > summary.layer-row {
-  padding-left: max(24px, min(calc(var(--layer-depth, 0) * 10px + 24px), 96px)) !important;
+  padding-left: 20px !important;
 }
 
 #layersRegion .layers-list-container.is-tree-mode .layer-tree-node > summary::before,
 #layersInspectorSection .layers-list-container.is-tree-mode .layer-tree-node > summary::before {
-  left: max(8px, min(calc(var(--layer-depth, 0) * 10px + 8px), 80px)) !important;
-  opacity: 0.76 !important;
+  left: 8px !important;
+  opacity: 0.7 !important;
 }
 
 #layersRegion .layers-list-container.is-tree-mode .layer-tree-children,
 #layersInspectorSection .layers-list-container.is-tree-mode .layer-tree-children {
-  margin: 6px 0 0 14px !important;
-  padding-left: 10px !important;
-  border-left: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 72%, transparent) !important;
+  margin: 4px 0 0 6px !important;
+  padding-left: 6px !important;
+  border-left: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 58%, transparent) !important;
 }
 
 #layersRegion .layers-list-container.is-tree-mode .layer-tree-node > .layer-row-actions.is-detached,
 #layersInspectorSection .layers-list-container.is-tree-mode .layer-tree-node > .layer-row-actions.is-detached {
   top: 50% !important;
-  right: 10px !important;
+  right: 7px !important;
   transform: translateY(-50%) !important;
-  gap: 4px !important;
+  gap: 3px !important;
 }
 
 #layersRegion .layers-list-container.is-tree-mode .layer-tree-node > summary .layer-trailing,
 #layersInspectorSection .layers-list-container.is-tree-mode .layer-tree-node > summary .layer-trailing {
-  padding-right: 78px !important;
+  padding-right: 58px !important;
 }
 
 #layersRegion .layer-label-input,
 #layersInspectorSection .layer-label-input {
-  min-height: 30px !important;
-  border-radius: 9px !important;
-  padding: 4px 8px !important;
+  min-height: 26px !important;
+  padding: 3px 7px !important;
+  border-radius: 7px !important;
   background: var(--premium-panel, var(--shell-panel)) !important;
   color: var(--shell-text) !important;
-  font-size: 13px !important;
+  font-size: 12px !important;
 }
 
 @media (max-width: 1280px) {
   #layersRegion .layer-row,
   #layersInspectorSection .layer-row {
-    grid-template-columns: 28px 32px minmax(0, 1fr) auto !important;
-    min-height: 56px !important;
-  }
-
-  #layersRegion .layer-status-list,
-  #layersInspectorSection .layer-status-list {
-    display: none !important;
-  }
-}
-
-@media (max-width: 520px) {
-  #layersRegion .layer-row,
-  #layersInspectorSection .layer-row {
-    grid-template-columns: 32px minmax(0, 1fr) auto !important;
-    min-height: 58px !important;
-  }
-
-  #layersRegion .layer-drag-handle,
-  #layersInspectorSection .layer-drag-handle {
-    display: none !important;
-  }
-
-  #layersRegion .layer-type-glyph,
-  #layersInspectorSection .layer-type-glyph {
-    width: 30px !important;
-    height: 30px !important;
-  }
-
-  #layersRegion .layer-row-actions,
-  #layersInspectorSection .layer-row-actions {
-    gap: 3px !important;
+    min-height: 42px !important;
+    padding: 5px 6px !important;
   }
 
   #layersRegion .layer-action-btn,
   #layersInspectorSection .layer-action-btn {
-    width: 36px !important;
-    min-width: 36px !important;
-    height: 36px !important;
-    min-height: 36px !important;
+    width: 27px !important;
+    min-width: 27px !important;
+    height: 27px !important;
+    min-height: 27px !important;
+  }
+}
+
+@media (max-width: 520px) {
+  #layersRegion .layer-row:has(.layer-drag-handle),
+  #layersInspectorSection .layer-row:has(.layer-drag-handle) {
+    grid-template-columns: 22px 26px minmax(0, 1fr) auto !important;
+  }
+
+  #layersRegion .layer-meta,
+  #layersInspectorSection .layer-meta {
+    display: none !important;
   }
 }


### PR DESCRIPTION
## Summary

Repairs the Layers panel layout after the previous oversized layer-card pass.

User feedback screenshot showed the issue clearly:

- the Layers section did not fit the narrow rail;
- rows were too large;
- nested layers consumed too much horizontal space;
- action buttons overlapped/competed with labels;
- the helper hint used valuable space;
- the section felt visually noisy and hard to understand.

This PR changes the direction from large cards to a compact object-list pattern.

## What changed

- Removed the bulky helper hint inside the list.
- Removed status chips from the narrow layer list; state remains visible through eye/lock controls.
- Reduced row height, padding, radius, icon sizes and action button sizes.
- Changed the row grid to fit narrow columns: optional drag handle → type glyph → label/meta → actions.
- Reduced tree indentation so nested structures do not eat the whole rail.
- Kept active/hover/focus states visible but less heavy.
- Kept touch/click targets usable without making the whole row oversized.

## Safety notes

- CSS-only change in `editor/styles/layers-region.css`.
- No HTML/JS changes.
- No bridge/modelDoc/iframe/export/autosave/history changes.
- Shell UI only; no presentation DOM styling.
- Existing layer selection, visibility, lock, rename and reorder logic unchanged.

## Manual QA focus

Please check the Layers panel against the reported screenshot scenario:

1. The layer list must fit inside the narrow left rail.
2. Rows should not overlap each other.
3. Eye/lock buttons must not cover labels.
4. Nested layers should be readable without excessive indentation.
5. Active row should be visible but not huge.
6. At least 4-6 rows should be visible in a small rail area.
7. Light/dark themes should remain readable.