### PR TITLE
fix(layers): flatten standalone layers into calm compact list

### DIFF
--- a/editor/styles/layers-region.css
+++ b/editor/styles/layers-region.css
@@ -1,9 +1,12 @@
 /* =============================================================================
  * layers-region.css — persistent Layers panel styles (ADR-031 + ADR-032)
  *
- * Shell-side styles for the standalone Layers panel and inspector-hosted
- * layers list. This file must keep the layers area compact: the left rail is
- * narrow, so rows should behave like a dense object list, not large cards.
+ * UX contract:
+ * - The standalone left-rail Layers panel is a compact object list.
+ * - It must stay readable in a narrow column.
+ * - Tree depth must not consume the rail width.
+ * - Row click selects; small action buttons remain separate and predictable.
+ * - No iframe/presentation content is styled here.
  * ============================================================================= */
 
 @layer layers-region {
@@ -29,74 +32,6 @@
     width: 100%;
   }
 
-  /* Tree view -------------------------------------------------------------- */
-  .layer-row[data-layer-depth] {
-    padding-left: min(calc(var(--layer-depth, 0) * 6px), 36px);
-  }
-
-  .layers-list-container.is-tree-mode .layer-tree-node {
-    display: block;
-    position: relative;
-  }
-
-  .layers-list-container.is-tree-mode .layer-tree-node > summary {
-    list-style: none;
-    cursor: pointer;
-    position: relative;
-    padding-left: 18px;
-  }
-
-  .layers-list-container.is-tree-mode .layer-tree-node > summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .layers-list-container.is-tree-mode .layer-tree-node > summary::before {
-    content: "";
-    position: absolute;
-    left: 6px;
-    top: 50%;
-    width: 0;
-    height: 0;
-    border: 4px solid transparent;
-    border-left-color: currentColor;
-    transform: translateY(-50%);
-    transform-origin: 2px 50%;
-    opacity: 0.58;
-    pointer-events: none;
-    transition: transform var(--motion-micro, 120ms) var(--ease-out, ease);
-  }
-
-  .layers-list-container.is-tree-mode .layer-tree-node[open] > summary::before {
-    transform: translateY(-50%) rotate(90deg);
-  }
-
-  .layers-list-container.is-tree-mode .layer-tree-node > .layer-row-actions.is-detached {
-    position: absolute;
-    top: 50%;
-    right: 6px;
-    z-index: 2;
-    display: flex;
-    gap: 3px;
-    transform: translateY(-50%);
-    pointer-events: auto;
-  }
-
-  .layers-list-container.is-tree-mode .layer-tree-node > summary .layer-trailing {
-    padding-right: 58px;
-  }
-
-  .layers-list-container.is-tree-mode .layer-tree-children {
-    display: block;
-    margin: 4px 0 0 8px;
-    padding-left: 6px;
-    border-left: 1px solid color-mix(in srgb, var(--shell-border-strong) 44%, transparent);
-  }
-
-  .layers-list-container.is-tree-mode .layer-tree-node:not([open]) .layer-tree-children {
-    display: none;
-  }
-
-  /* Inline rename ---------------------------------------------------------- */
   .layer-label-input {
     width: 100%;
     min-height: 26px;
@@ -116,16 +51,13 @@
 }
 
 /* =============================================================================
- * Compact repair layer — fixes the oversized PR #7 layout.
- *
- * Goal: the Layers section must fit a narrow rail. Rows are compact, readable,
- * and click-safe: row selects, eye/lock act as separate controls, labels do
- * not sit under action buttons, tree indentation is shallow.
+ * Calm compact layer list
  * ============================================================================= */
 
 #layersRegion .panel-header {
-  min-height: 44px !important;
-  padding: 9px 12px !important;
+  min-height: 42px !important;
+  padding: 8px 12px !important;
+  border-bottom-color: color-mix(in srgb, var(--shell-border-strong) 42%, transparent) !important;
 }
 
 #layersRegion .panel-header h2 {
@@ -139,45 +71,94 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 11px !important;
+  line-height: 1.3 !important;
 }
 
 #layersRegion .layers-region-body {
   padding: 8px !important;
-  background: color-mix(in srgb, var(--premium-panel, var(--shell-panel)) 94%, transparent) !important;
+  background: color-mix(in srgb, var(--premium-panel, var(--shell-panel)) 96%, transparent) !important;
 }
 
 #layersRegion .layers-list-container,
 #layersInspectorSection .layers-list-container {
   display: flex !important;
   flex-direction: column !important;
-  gap: 5px !important;
+  gap: 4px !important;
+  width: 100% !important;
   max-height: none !important;
-  padding: 6px !important;
-  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 70%, transparent) !important;
+  padding: 4px !important;
+  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 54%, transparent) !important;
   border-radius: 12px !important;
-  background: color-mix(in srgb, var(--premium-panel-soft, var(--shell-field-bg)) 72%, transparent) !important;
+  background: color-mix(in srgb, var(--premium-panel-soft, var(--shell-field-bg)) 60%, transparent) !important;
   overflow: auto !important;
 }
 
-/* Hide the bulky helper from PR #7. The header already says this is Layers. */
 #layersRegion .layers-list-container::before,
 #layersInspectorSection .layers-list-container::before {
   display: none !important;
   content: none !important;
 }
 
+/* Standalone rail: visually flatten tree-mode. The DOM can remain a tree for
+   keyboard/state logic, but the user sees a simple, consistent object list. */
+#layersRegion .layers-list-container.is-tree-mode {
+  gap: 4px !important;
+}
+
+#layersRegion .layers-list-container.is-tree-mode .layer-tree-node {
+  display: contents !important;
+  position: static !important;
+  margin: 0 !important;
+}
+
+#layersRegion .layers-list-container.is-tree-mode .layer-tree-node > summary {
+  list-style: none !important;
+}
+
+#layersRegion .layers-list-container.is-tree-mode .layer-tree-node > summary::-webkit-details-marker {
+  display: none !important;
+}
+
+#layersRegion .layers-list-container.is-tree-mode .layer-tree-node > summary::before {
+  display: none !important;
+  content: none !important;
+}
+
+#layersRegion .layers-list-container.is-tree-mode .layer-tree-children {
+  display: contents !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  border: 0 !important;
+}
+
+#layersRegion .layers-list-container.is-tree-mode .layer-tree-node:not([open]) .layer-tree-children {
+  display: contents !important;
+}
+
+/* Detached action buttons in tree-mode caused the floating eye/lock pile-up.
+   Hide only those detached parent actions in the standalone rail. Leaf rows and
+   flat rows still keep their normal inline actions. */
+#layersRegion .layers-list-container.is-tree-mode .layer-row-actions.is-detached {
+  display: none !important;
+}
+
+#layersRegion .layers-list-container.is-tree-mode .layer-tree-node > summary .layer-trailing {
+  padding-right: 0 !important;
+}
+
 #layersRegion .layer-row,
 #layersInspectorSection .layer-row {
   position: relative !important;
   display: grid !important;
-  grid-template-columns: 26px minmax(0, 1fr) auto !important;
+  grid-template-columns: 24px minmax(0, 1fr) auto !important;
   align-items: center !important;
-  gap: 6px !important;
-  min-height: 44px !important;
-  padding: 6px 7px !important;
-  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 58%, transparent) !important;
-  border-radius: 11px !important;
-  background: color-mix(in srgb, var(--premium-panel, var(--shell-panel)) 94%, transparent) !important;
+  column-gap: 7px !important;
+  min-height: 38px !important;
+  width: 100% !important;
+  padding: 5px 6px !important;
+  border: 1px solid transparent !important;
+  border-radius: 10px !important;
+  background: transparent !important;
   box-shadow: none !important;
   cursor: pointer !important;
   touch-action: manipulation;
@@ -185,44 +166,46 @@
 
 #layersRegion .layer-row:has(.layer-drag-handle),
 #layersInspectorSection .layer-row:has(.layer-drag-handle) {
-  grid-template-columns: 22px 26px minmax(0, 1fr) auto !important;
+  grid-template-columns: 18px 24px minmax(0, 1fr) auto !important;
+}
+
+#layersRegion .layer-row[data-layer-depth],
+#layersInspectorSection .layer-row[data-layer-depth] {
+  padding-left: 6px !important;
 }
 
 #layersRegion .layer-row:hover,
 #layersInspectorSection .layer-row:hover {
-  border-color: color-mix(in srgb, var(--shell-accent) 34%, var(--premium-border, var(--shell-border-strong))) !important;
-  background: color-mix(in srgb, var(--premium-panel, var(--shell-panel)) 82%, var(--shell-accent-soft) 18%) !important;
-  box-shadow: 0 3px 10px color-mix(in srgb, var(--shell-accent) 8%, transparent) !important;
+  border-color: color-mix(in srgb, var(--shell-accent) 24%, transparent) !important;
+  background: color-mix(in srgb, var(--shell-accent-soft) 22%, var(--premium-panel, var(--shell-panel)) 78%) !important;
 }
 
 #layersRegion .layer-row.is-active,
 #layersInspectorSection .layer-row.is-active,
 #layersRegion .layer-row[aria-current="true"],
 #layersInspectorSection .layer-row[aria-current="true"] {
-  border-color: color-mix(in srgb, var(--shell-accent) 68%, var(--premium-border, var(--shell-border-strong))) !important;
-  background: color-mix(in srgb, var(--premium-panel, var(--shell-panel)) 76%, var(--shell-accent-soft) 24%) !important;
-  box-shadow:
-    inset 3px 0 0 var(--shell-accent),
-    0 0 0 1px color-mix(in srgb, var(--shell-accent) 16%, transparent) !important;
+  border-color: color-mix(in srgb, var(--shell-accent) 72%, transparent) !important;
+  background: color-mix(in srgb, var(--shell-accent-soft) 42%, var(--premium-panel, var(--shell-panel)) 58%) !important;
+  box-shadow: inset 3px 0 0 var(--shell-accent) !important;
 }
 
 #layersRegion .layer-row:focus-visible,
 #layersInspectorSection .layer-row:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--shell-accent) 48%, transparent) !important;
-  outline-offset: 2px !important;
+  outline: 2px solid color-mix(in srgb, var(--shell-accent) 42%, transparent) !important;
+  outline-offset: 1px !important;
 }
 
 #layersRegion .layer-drag-handle,
 #layersInspectorSection .layer-drag-handle {
-  width: 22px !important;
-  min-width: 22px !important;
+  width: 18px !important;
+  min-width: 18px !important;
   height: 28px !important;
   min-height: 28px !important;
   padding: 0 !important;
   border: 0 !important;
-  border-radius: 7px !important;
+  border-radius: 6px !important;
   background: transparent !important;
-  color: color-mix(in srgb, var(--shell-text-muted) 78%, transparent) !important;
+  color: color-mix(in srgb, var(--shell-text-muted) 58%, transparent) !important;
   cursor: grab !important;
 }
 
@@ -230,7 +213,7 @@
 #layersInspectorSection .layer-drag-handle:hover,
 #layersRegion .layer-drag-handle:focus-visible,
 #layersInspectorSection .layer-drag-handle:focus-visible {
-  background: color-mix(in srgb, var(--shell-accent-soft) 44%, transparent) !important;
+  background: color-mix(in srgb, var(--shell-accent-soft) 40%, transparent) !important;
   color: var(--shell-accent) !important;
 }
 
@@ -241,17 +224,17 @@
 
 #layersRegion .layer-type-glyph,
 #layersInspectorSection .layer-type-glyph {
-  width: 26px !important;
-  min-width: 26px !important;
-  height: 26px !important;
-  min-height: 26px !important;
+  width: 24px !important;
+  min-width: 24px !important;
+  height: 24px !important;
+  min-height: 24px !important;
   display: inline-grid !important;
   place-items: center !important;
-  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 54%, transparent) !important;
-  border-radius: 8px !important;
-  background: color-mix(in srgb, var(--premium-control-bg, var(--shell-field-bg)) 78%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 46%, transparent) !important;
+  border-radius: 7px !important;
+  background: color-mix(in srgb, var(--premium-control-bg, var(--shell-field-bg)) 70%, transparent) !important;
   color: var(--shell-text-muted) !important;
-  font-size: 12px !important;
+  font-size: 11px !important;
   font-weight: 700 !important;
   line-height: 1 !important;
 }
@@ -260,8 +243,8 @@
 #layersInspectorSection .layer-row.is-active .layer-type-glyph,
 #layersRegion .layer-row[aria-current="true"] .layer-type-glyph,
 #layersInspectorSection .layer-row[aria-current="true"] .layer-type-glyph {
-  border-color: color-mix(in srgb, var(--shell-accent) 42%, var(--premium-border, var(--shell-border-strong))) !important;
-  background: color-mix(in srgb, var(--shell-accent-soft) 52%, var(--premium-control-bg, var(--shell-field-bg)) 48%) !important;
+  border-color: color-mix(in srgb, var(--shell-accent) 36%, var(--premium-border, var(--shell-border-strong))) !important;
+  background: color-mix(in srgb, var(--shell-accent-soft) 50%, var(--premium-control-bg, var(--shell-field-bg)) 50%) !important;
   color: var(--shell-accent) !important;
 }
 
@@ -269,7 +252,7 @@
 #layersInspectorSection .layer-main {
   min-width: 0 !important;
   display: grid !important;
-  gap: 2px !important;
+  gap: 1px !important;
 }
 
 #layersRegion .layer-label,
@@ -283,7 +266,7 @@
   color: var(--shell-text) !important;
   font-size: 12px !important;
   font-weight: 700 !important;
-  line-height: 1.2 !important;
+  line-height: 1.18 !important;
 }
 
 #layersRegion .layer-meta,
@@ -295,21 +278,19 @@
   text-overflow: ellipsis !important;
   white-space: nowrap !important;
   color: var(--shell-text-muted) !important;
-  font-size: 10px !important;
-  line-height: 1.2 !important;
+  font-size: 9.5px !important;
+  line-height: 1.15 !important;
 }
 
 #layersRegion .layer-trailing,
 #layersInspectorSection .layer-trailing {
   min-width: 0 !important;
-  display: flex !important;
+  display: inline-flex !important;
   align-items: center !important;
   justify-content: flex-end !important;
-  gap: 4px !important;
+  gap: 3px !important;
 }
 
-/* Status chips created horizontal pressure in the rail. State remains visible
-   through the eye/lock icons; detailed chips belong in inspector, not this list. */
 #layersRegion .layer-status-list,
 #layersInspectorSection .layer-status-list {
   display: none !important;
@@ -326,16 +307,16 @@
 
 #layersRegion .layer-action-btn,
 #layersInspectorSection .layer-action-btn {
-  width: 28px !important;
-  min-width: 28px !important;
-  height: 28px !important;
-  min-height: 28px !important;
+  width: 26px !important;
+  min-width: 26px !important;
+  height: 26px !important;
+  min-height: 26px !important;
   padding: 0 !important;
   display: inline-grid !important;
   place-items: center !important;
-  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 58%, transparent) !important;
-  border-radius: 9px !important;
-  background: color-mix(in srgb, var(--premium-control-bg, var(--shell-field-bg)) 70%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 48%, transparent) !important;
+  border-radius: 8px !important;
+  background: color-mix(in srgb, var(--premium-control-bg, var(--shell-field-bg)) 62%, transparent) !important;
   color: var(--shell-text-muted) !important;
   cursor: pointer !important;
 }
@@ -344,8 +325,8 @@
 #layersInspectorSection .layer-action-btn:hover,
 #layersRegion .layer-action-btn:focus-visible,
 #layersInspectorSection .layer-action-btn:focus-visible {
-  border-color: color-mix(in srgb, var(--shell-accent) 40%, var(--premium-border, var(--shell-border-strong))) !important;
-  background: color-mix(in srgb, var(--shell-accent-soft) 54%, var(--premium-control-bg, var(--shell-field-bg)) 46%) !important;
+  border-color: color-mix(in srgb, var(--shell-accent) 38%, var(--premium-border, var(--shell-border-strong))) !important;
+  background: color-mix(in srgb, var(--shell-accent-soft) 48%, var(--premium-control-bg, var(--shell-field-bg)) 52%) !important;
   color: var(--shell-accent) !important;
 }
 
@@ -356,9 +337,7 @@
 
 #layersRegion .layer-action-btn.is-hidden,
 #layersInspectorSection .layer-action-btn.is-hidden {
-  opacity: 1 !important;
-  color: color-mix(in srgb, var(--shell-text-muted) 72%, transparent) !important;
-  background: color-mix(in srgb, var(--shell-text-muted) 10%, var(--premium-control-bg, var(--shell-field-bg)) 90%) !important;
+  opacity: 0.72 !important;
 }
 
 #layersRegion .layer-action-btn.is-locked,
@@ -366,51 +345,9 @@
   color: var(--intent-error-fg, var(--shell-danger)) !important;
 }
 
-/* Compact tree mode: nesting indicator without wasting half the rail. */
-#layersRegion .layers-list-container.is-tree-mode,
-#layersInspectorSection .layers-list-container.is-tree-mode {
-  gap: 4px !important;
-}
-
-#layersRegion .layers-list-container.is-tree-mode .layer-tree-node,
-#layersInspectorSection .layers-list-container.is-tree-mode .layer-tree-node {
-  margin: 0 !important;
-}
-
-#layersRegion .layers-list-container.is-tree-mode .layer-tree-node > summary.layer-row,
-#layersInspectorSection .layers-list-container.is-tree-mode .layer-tree-node > summary.layer-row {
-  padding-left: 20px !important;
-}
-
-#layersRegion .layers-list-container.is-tree-mode .layer-tree-node > summary::before,
-#layersInspectorSection .layers-list-container.is-tree-mode .layer-tree-node > summary::before {
-  left: 8px !important;
-  opacity: 0.7 !important;
-}
-
-#layersRegion .layers-list-container.is-tree-mode .layer-tree-children,
-#layersInspectorSection .layers-list-container.is-tree-mode .layer-tree-children {
-  margin: 4px 0 0 6px !important;
-  padding-left: 6px !important;
-  border-left: 1px solid color-mix(in srgb, var(--premium-border, var(--shell-border-strong)) 58%, transparent) !important;
-}
-
-#layersRegion .layers-list-container.is-tree-mode .layer-tree-node > .layer-row-actions.is-detached,
-#layersInspectorSection .layers-list-container.is-tree-mode .layer-tree-node > .layer-row-actions.is-detached {
-  top: 50% !important;
-  right: 7px !important;
-  transform: translateY(-50%) !important;
-  gap: 3px !important;
-}
-
-#layersRegion .layers-list-container.is-tree-mode .layer-tree-node > summary .layer-trailing,
-#layersInspectorSection .layers-list-container.is-tree-mode .layer-tree-node > summary .layer-trailing {
-  padding-right: 58px !important;
-}
-
 #layersRegion .layer-label-input,
 #layersInspectorSection .layer-label-input {
-  min-height: 26px !important;
+  min-height: 25px !important;
   padding: 3px 7px !important;
   border-radius: 7px !important;
   background: var(--premium-panel, var(--shell-panel)) !important;
@@ -421,23 +358,23 @@
 @media (max-width: 1280px) {
   #layersRegion .layer-row,
   #layersInspectorSection .layer-row {
-    min-height: 42px !important;
-    padding: 5px 6px !important;
+    min-height: 36px !important;
+    padding: 4px 5px !important;
   }
 
   #layersRegion .layer-action-btn,
   #layersInspectorSection .layer-action-btn {
-    width: 27px !important;
-    min-width: 27px !important;
-    height: 27px !important;
-    min-height: 27px !important;
+    width: 25px !important;
+    min-width: 25px !important;
+    height: 25px !important;
+    min-height: 25px !important;
   }
 }
 
 @media (max-width: 520px) {
   #layersRegion .layer-row:has(.layer-drag-handle),
   #layersInspectorSection .layer-row:has(.layer-drag-handle) {
-    grid-template-columns: 22px 26px minmax(0, 1fr) auto !important;
+    grid-template-columns: 18px 24px minmax(0, 1fr) auto !important;
   }
 
   #layersRegion .layer-meta,


### PR DESCRIPTION
## Summary

Repairs the Layers panel after the latest screenshot feedback.

The previous compact repair still looked bad because the standalone left rail was still visually behaving like a nested tree:

- nesting consumed too much width;
- parent rows created a staircase effect;
- detached eye/lock actions floated over the list;
- the section looked noisy instead of clear.

This PR changes the standalone Layers rail to a calm compact object-list pattern.

## What changed

- Visually flattens tree-mode inside `#layersRegion` only.
- Keeps the underlying DOM/tree state intact, but the left rail no longer renders as a deep staircase.
- Hides detached parent actions in the standalone rail to remove the floating eye/lock pile-up.
- Keeps normal inline actions for regular rows.
- Reduces row height, padding, icon size and visual weight.
- Removes status chips and heavy cards from the narrow list.
- Makes the selected row obvious but not oversized.
- Keeps labels readable with ellipsis instead of overlap.

## Safety notes

- CSS-only change in `editor/styles/layers-region.css`.
- No JS/HTML changes.
- No bridge/modelDoc/iframe/export/autosave/history changes.
- Does not change actual selection/visibility/lock/reorder logic.
- Shell UI only; no presentation DOM styling.

## Manual QA focus

Please check exactly the screenshot scenario:

1. Standalone left Layers panel with many nested elements.
2. No staircase/card pile-up.
3. No floating eye/lock buttons over text.
4. Row labels remain readable and truncated.
5. Active row is clear but compact.
6. At least 7-10 rows are visible in the panel.
7. Light/dark contrast remains usable.

Known tradeoff: the standalone rail now intentionally prioritizes a flat novice-friendly list. Deep tree manipulation should be handled in a future dedicated advanced structure view, not in the narrow default rail.